### PR TITLE
Fixed app:install for windows

### DIFF
--- a/src/AppBundle/Command/InstallCommand.php
+++ b/src/AppBundle/Command/InstallCommand.php
@@ -31,7 +31,9 @@ use Symfony\Component\Process\Process;
 class InstallCommand extends ContainerAwareCommand
 {
     const DATA_ROOT_PATH = 'vendor' . DIRECTORY_SEPARATOR . 'sulu' . DIRECTORY_SEPARATOR . 'demo-data' . DIRECTORY_SEPARATOR . 'data';
+
     const SQL_FILE_PATH = self::DATA_ROOT_PATH . DIRECTORY_SEPARATOR . 'sulu_demo.sql';
+
     const MEDIA_DIRECTORY_PATH = self::DATA_ROOT_PATH . DIRECTORY_SEPARATOR . 'uploads' . DIRECTORY_SEPARATOR . 'media';
 
     /** @var SymfonyStyle */
@@ -225,7 +227,7 @@ class InstallCommand extends ContainerAwareCommand
         $cmdLine .= ' --env=' . $this->getContainer()->getParameter('kernel.environment');
 
         $process = new Process($this->getPhp() . ' ' . $rootDir . DIRECTORY_SEPARATOR . $cmdLine);
-        if ('\\' !== DIRECTORY_SEPARATOR){
+        if ('\\' !== DIRECTORY_SEPARATOR) {
             $process->setTty(true);
         }
 

--- a/src/AppBundle/Command/InstallCommand.php
+++ b/src/AppBundle/Command/InstallCommand.php
@@ -225,7 +225,10 @@ class InstallCommand extends ContainerAwareCommand
         $cmdLine .= ' --env=' . $this->getContainer()->getParameter('kernel.environment');
 
         $process = new Process($this->getPhp() . ' ' . $rootDir . DIRECTORY_SEPARATOR . $cmdLine);
-        $process->setTty(true);
+        if ('\\' !== DIRECTORY_SEPARATOR){
+            $process->setTty(true);
+        }
+
         $process->setTimeout(null);
         $process->run(function ($type, $out) {
             $this->io->writeln($out);


### PR DESCRIPTION
Fixed app:install for windows by disabling setting tty if on a windows system. 

The call to Process->setTty is only relevant on non-windows systems. In the Process class, the only place Tty is used is inside an if condition that checks if the command is being executed on a non-windows system.

| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #38
| Related issues/PRs | -
| License            | MIT
| Documentation PR   | -