### PR TITLE
[Example] Overwrite styling of the administration interface

### DIFF
--- a/assets/admin/postcss.config.js
+++ b/assets/admin/postcss.config.js
@@ -1,0 +1,2 @@
+/* reuse the postcss configuration included in sulu */
+module.exports = require('../../vendor/sulu/sulu/postcss.config.js');

--- a/assets/admin/style-overwrites/login.scss
+++ b/assets/admin/style-overwrites/login.scss
@@ -1,0 +1,7 @@
+/* import original stylesheet to keep original styling */
+@import 'sulu-admin-bundle/containers/Login/login.scss';
+
+/* overwrite style for specific elements */
+.login-container {
+    background-color: lightpink;
+}

--- a/assets/admin/webpack.config.js
+++ b/assets/admin/webpack.config.js
@@ -14,5 +14,11 @@ module.exports = (env, argv) => {
     const config = webpackConfig(env, argv);
     config.entry = path.resolve(__dirname, 'index.js');
 
+    const suluPath = path.resolve(__dirname, '../../vendor/sulu/sulu/');
+    const loginScssPath = path.resolve(suluPath, 'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/login.scss');
+
+    /* overwrite stylesheet of sulu login component with custom stylesheet of project */
+    config.resolve.alias[loginScssPath] = path.resolve(__dirname, 'style-overwrites/login.scss');
+
     return config;
 };


### PR DESCRIPTION
#### What's in this PR?

This PR demonstrates how to overwrite/extend the default styling of the administration interface of Sulu. 

> Please be aware that the styling of the administration interface might change between different Sulu versions and therefore this might break when updating the `sulu/sulu` dependency of the project. 

![Screenshot 2020-09-29 at 14 34 56](https://user-images.githubusercontent.com/13310795/94559079-fe360080-0260-11eb-83d4-444603d78b59.png)

To apply the changes, the administration frontend application needs to be rebuilt by executing `npm install` and `npm run build` in the `assets/admin` directory.