### PR TITLE
[Example] Adjust ckeditor configuration

### DIFF
--- a/assets/admin/index.js
+++ b/assets/admin/index.js
@@ -18,6 +18,13 @@ import 'sulu-snippet-bundle';
 import 'sulu-website-bundle';
 
 // Implement custom extensions here
+import {ckeditorPluginRegistry, ckeditorConfigRegistry} from 'sulu-admin-bundle/containers';
+import Font from '@ckeditor/ckeditor5-font/src/font';
+
+ckeditorPluginRegistry.add(Font);
+ckeditorConfigRegistry.add((config) => ({
+    toolbar: [...config.toolbar, 'fontSize', 'fontFamily', 'fontColor', 'fontBackgroundColor'],
+}));
 
 // Start admin application
 startAdmin();

--- a/assets/admin/package.json
+++ b/assets/admin/package.json
@@ -8,6 +8,7 @@
         "watch": "webpack --mode development -w"
     },
     "dependencies": {
+        "@ckeditor/ckeditor5-font": "^18.0.0",
         "mobx": "^4.0.0",
         "mobx-react": "^5.0.0",
         "react": "^16.2.0",


### PR DESCRIPTION
#### What's in this PR?

This PR demonstrates how to configure the ckeditor instance which is used for `text_editor` properties. It utilizes the [`ckeditorPluginRegistry` and `ckeditorConfigRegistry`](https://jsdocs.sulu.io/latest/#ckeditor5) of Sulu to add and configure the [CKEditor 5 font feature](https://ckeditor.com/docs/ckeditor5/latest/api/font.html).

![Screenshot 2020-09-29 at 17 11 22](https://user-images.githubusercontent.com/13310795/94577398-d3ef3d80-0276-11eb-92cd-ea953aff17d9.png)

To apply the changes, the administration frontend application needs to be rebuilt by executing `npm install` and `npm run build` in the `assets/admin` directory.