### PR TITLE
[Example] Register and use custom content type in form

### DIFF
--- a/assets/admin/fields/Currency.js
+++ b/assets/admin/fields/Currency.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import {Number} from 'sulu-admin-bundle/components';
+
+class Currency extends React.Component{
+    handleInputChange = (floatAmount) => {
+        const centAmount = floatAmount !== undefined ?
+            Math.floor(floatAmount * 100)
+            : undefined;
+
+        const allowNegativeAmount = this.props.schemaOptions.allowNegativeAmount !== undefined
+            ? this.props.schemaOptions.allowNegativeAmount.value
+            : false;
+
+        const normalizedCentAmount = !allowNegativeAmount && centAmount !== undefined
+            ? Math.max(0, centAmount)
+            : centAmount;
+
+        this.props.onChange(normalizedCentAmount);
+        this.props.onFinish();
+    };
+
+    render() {
+        const {dataPath, disabled, error, value: centAmount} = this.props;
+
+        const floatAmount = centAmount !== undefined
+            ? centAmount / 100
+            : undefined;
+
+        return (
+            <Number
+                disabled={!!disabled}
+                icon="su-dollar"
+                id={dataPath}
+                onChange={this.handleInputChange}
+                step={0.01}
+                valid={!error}
+                value={floatAmount}
+            />
+        );
+    }
+}
+
+export default Currency;

--- a/assets/admin/index.js
+++ b/assets/admin/index.js
@@ -18,6 +18,10 @@ import 'sulu-snippet-bundle';
 import 'sulu-website-bundle';
 
 // Implement custom extensions here
+import {fieldRegistry} from 'sulu-admin-bundle/containers';
+import Currency from "./fields/Currency";
+
+fieldRegistry.add('currency', Currency);
 
 // Start admin application
 startAdmin();

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -47,3 +47,6 @@ services:
 
     App\Content\Type\AlbumSelection:
         tags: [{name: 'sulu.content.type', alias: 'album_selection'}]
+
+    App\Content\Type\Currency:
+        tags: [ { name: 'sulu.content.type', alias: 'currency' } ]

--- a/config/templates/pages/homepage.xml
+++ b/config/templates/pages/homepage.xml
@@ -60,6 +60,17 @@
             </meta>
         </property>
 
+        <property name="price" type="currency">
+            <meta>
+                <title lang="en">Price</title>
+                <title lang="de">Preis</title>
+            </meta>
+
+            <params>
+                <param name="allowNegativeAmount" value="true"/>
+            </params>
+        </property>
+
         <!-- @see https://docs.sulu.io/en/2.1/book/templates.html#including-other-templates -->
         <xi:include href="../includes/blocks.xml"
                     xpointer="xmlns(sulu=http://schemas.sulu.io/template/template)xpointer(/sulu:properties/sulu:block)"/>

--- a/src/Content/Type/Currency.php
+++ b/src/Content/Type/Currency.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Type;
+
+use Sulu\Component\Content\SimpleContentType;
+
+class Currency extends SimpleContentType
+{
+    public function __construct()
+    {
+        parent::__construct('currency');
+    }
+}

--- a/templates/pages/homepage.html.twig
+++ b/templates/pages/homepage.html.twig
@@ -5,5 +5,7 @@
 {% endblock %}
 
 {% block contentBody %}
+    Price Content Type Value: {{ content.price|default('not set') }}
+
     {% include 'includes/blocks.html.twig' %}
 {% endblock %}


### PR DESCRIPTION
#### What's in this PR?

This PR demonstrates how to implement a custom content type, which can be used inside of page templates and custom entity forms. The example registers a simple `currency` content type that displays an input with an icon in the administration interface and stores its amount in number of cents on the server. 

![Screenshot 2020-10-06 at 16 46 34](https://user-images.githubusercontent.com/13310795/95217494-85501f00-07f3-11eb-81a3-991256ecc991.png)

To apply the changes, the administration frontend application needs to be rebuilt by executing `npm install` and `npm run build` in the `assets/admin` directory.