### PR TITLE
[Example] Add custom item action to list view

### DIFF
--- a/assets/admin/index.js
+++ b/assets/admin/index.js
@@ -18,6 +18,10 @@ import 'sulu-snippet-bundle';
 import 'sulu-website-bundle';
 
 // Implement custom extensions here
+import {listItemActionRegistry} from 'sulu-admin-bundle/views';
+import AlertNameItemAction from "./listItemActions/AlertNameItemAction";
+
+listItemActionRegistry.add('app.alert_name', AlertNameItemAction);
 
 // Start admin application
 startAdmin();

--- a/assets/admin/listItemActions/AlertNameItemAction.js
+++ b/assets/admin/listItemActions/AlertNameItemAction.js
@@ -1,0 +1,18 @@
+import {translate} from 'sulu-admin-bundle/utils';
+import {AbstractListItemAction} from 'sulu-admin-bundle/views';
+
+export default class AlertNameItemAction extends AbstractListItemAction {
+    getItemActionConfig(item) {
+        const {disabled_ids: disabledIds = []} = this.options;
+
+        return {
+            icon: 'su-bell',
+            disabled: item ? disabledIds.includes(item['id']) : false,
+            onClick: item ? () => this.handleClick(item) : undefined,
+        };
+    }
+
+    handleClick = (item) => {
+        alert(translate('app.clicked_contact') + ':\n' + item.firstName + ' ' + item.lastName);
+    };
+}

--- a/src/Admin/AppAdmin.php
+++ b/src/Admin/AppAdmin.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin;
+
+use Sulu\Bundle\AdminBundle\Admin\Admin;
+use Sulu\Bundle\AdminBundle\Admin\View\ListItemAction;
+use Sulu\Bundle\AdminBundle\Admin\View\ListViewBuilderInterface;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\ContactBundle\Admin\ContactAdmin;
+
+class AppAdmin extends Admin
+{
+    public function configureViews(ViewCollection $viewCollection): void
+    {
+        if ($viewCollection->has(ContactAdmin::CONTACT_LIST_VIEW)) {
+            /** @var ListViewBuilderInterface $contactListViewBuilder */
+            $contactListViewBuilder = $viewCollection->get(ContactAdmin::CONTACT_LIST_VIEW);
+            $contactListViewBuilder->addItemActions([
+                new ListItemAction('app.alert_name', ['disabled_ids' => [1]]),
+            ]);
+        }
+    }
+
+    public static function getPriority(): int
+    {
+        return ContactAdmin::getPriority() - 1;
+    }
+}

--- a/translations/admin.de.json
+++ b/translations/admin.de.json
@@ -9,5 +9,6 @@
     "app.album_selection_label": "{count} {count, plural, =1 {Album} other {Alben}} ausgewählt",
     "app.select_albums": "Alben auswählen",
     "app.no_album_selected": "Kein Album ausgewählt",
-    "app.select_album": "Album auswählen"
+    "app.select_album": "Album auswählen",
+    "app.clicked_contact": "Ausgewählter Kontakt"
 }

--- a/translations/admin.en.json
+++ b/translations/admin.en.json
@@ -9,5 +9,6 @@
     "app.album_selection_label": "{count} {count, plural, =1 {album} other {albums}} selected",
     "app.select_albums": "Select albums",
     "app.no_album_selected": "No album selected",
-    "app.select_album": "Select album"
+    "app.select_album": "Select album",
+    "app.clicked_contact": "Clicked Contact"
 }


### PR DESCRIPTION
#### What's in this PR?

This PR demonstrates how to add a custom item action to a list view of the administration interface of Sulu. The example adds a simple item action that outputs the name of the contact to the contact list view.

![Screenshot 2020-10-23 at 16 53 31](https://user-images.githubusercontent.com/13310795/97019180-4c80ab80-1550-11eb-85a8-158668e16ca5.png)

To apply the changes, the administration frontend application needs to be rebuilt by executing `npm install` and `npm run build` in the `assets/admin` directory.