### PR TITLE
[Example] Add selection content-type for custom entity

### DIFF
--- a/config/packages/sulu_admin.yaml
+++ b/config/packages/sulu_admin.yaml
@@ -25,6 +25,22 @@ sulu_admin:
                         icon: 'su-storage'
                         label: 'app.album_selection_label'
                         overlay_title: 'app.select_albums'
+            event_selection:
+                default_type: 'list_overlay'
+                resource_key: 'events'
+                view:
+                    name: 'app.event.add_form'
+                    result_to_view:
+                        id: 'id'
+                types:
+                    list_overlay:
+                        adapter: 'table'
+                        list_key: 'events'
+                        display_properties:
+                            - 'name'
+                        icon: 'su-calendar'
+                        label: 'app.event_selection_label'
+                        overlay_title: 'app.select_events'
         single_selection:
             single_album_selection:
                 default_type: 'list_overlay'
@@ -38,3 +54,19 @@ sulu_admin:
                         icon: 'su-storage'
                         empty_text: 'app.no_album_selected'
                         overlay_title: 'app.select_album'
+            single_event_selection:
+                default_type: 'list_overlay'
+                resource_key: 'events'
+                view:
+                    name: 'app.event.add_form'
+                    result_to_view:
+                        id: 'id'
+                types:
+                    list_overlay:
+                        adapter: 'table'
+                        list_key: 'events'
+                        display_properties:
+                            - 'name'
+                        icon: 'su-calendar'
+                        empty_text: 'app.no_event_selected'
+                        overlay_title: 'app.select_event'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -47,3 +47,9 @@ services:
 
     App\Content\Type\AlbumSelection:
         tags: [{name: 'sulu.content.type', alias: 'album_selection'}]
+
+    App\Content\Type\SingleEventSelection:
+        tags: [ { name: 'sulu.content.type', alias: 'single_event_selection' } ]
+
+    App\Content\Type\EventSelection:
+        tags: [ { name: 'sulu.content.type', alias: 'event_selection' } ]

--- a/src/Content/Type/EventSelection.php
+++ b/src/Content/Type/EventSelection.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Type;
+
+use App\Entity\Event;
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\SimpleContentType;
+
+class EventSelection extends SimpleContentType
+{
+    protected EntityManagerInterface $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+
+        parent::__construct('event_selection', []);
+    }
+
+    /**
+     * @return Event[]
+     */
+    public function getContentData(PropertyInterface $property): array
+    {
+        $ids = $property->getValue();
+
+        if (empty($ids)) {
+            return [];
+        }
+
+        $events = $this->entityManager->getRepository(Event::class)->findBy(['id' => $ids]);
+
+        $idPositions = array_flip($ids);
+        usort($events, function (Event $a, Event $b) use ($idPositions) {
+            return $idPositions[$a->getId()] - $idPositions[$b->getId()];
+        });
+
+        return $events;
+    }
+
+    /**
+     * @return array<string, array<int>|null>
+     */
+    public function getViewData(PropertyInterface $property): array
+    {
+        return [
+            'ids' => $property->getValue(),
+        ];
+    }
+}

--- a/src/Content/Type/SingleEventSelection.php
+++ b/src/Content/Type/SingleEventSelection.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Type;
+
+use App\Entity\Event;
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\SimpleContentType;
+
+class SingleEventSelection extends SimpleContentType
+{
+    protected EntityManagerInterface $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+
+        parent::__construct('single_event_selection', null);
+    }
+
+    public function getContentData(PropertyInterface $property): ?Event
+    {
+        $id = $property->getValue();
+
+        if (empty($id)) {
+            return null;
+        }
+
+        return $this->entityManager->getRepository(Event::class)->find($id);
+    }
+
+    /**
+     * @return array<string, int|null>
+     */
+    public function getViewData(PropertyInterface $property): array
+    {
+        return [
+            'id' => $property->getValue(),
+        ];
+    }
+}

--- a/translations/admin.de.json
+++ b/translations/admin.de.json
@@ -9,5 +9,9 @@
     "app.album_selection_label": "{count} {count, plural, =1 {Album} other {Alben}} ausgewählt",
     "app.select_albums": "Alben auswählen",
     "app.no_album_selected": "Kein Album ausgewählt",
-    "app.select_album": "Album auswählen"
+    "app.select_album": "Album auswählen",
+    "app.event_selection_label": "{count} {count, plural, =1 {Event} other {Events}} ausgewählt",
+    "app.select_events": "Events auswählen",
+    "app.no_event_selected": "Kein Event ausgewählt",
+    "app.select_event": "Event auswählen"
 }

--- a/translations/admin.en.json
+++ b/translations/admin.en.json
@@ -9,5 +9,9 @@
     "app.album_selection_label": "{count} {count, plural, =1 {album} other {albums}} selected",
     "app.select_albums": "Select albums",
     "app.no_album_selected": "No album selected",
-    "app.select_album": "Select album"
+    "app.select_album": "Select album",
+    "app.event_selection_label": "{count} {count, plural, =1 {event} other {events}} selected",
+    "app.select_events": "Select events",
+    "app.no_event_selected": "No event selected",
+    "app.select_event": "Select event"
 }


### PR DESCRIPTION
#### What's in this PR?

This PR demonstrates how to add a `selection` and `single_selection` content-type for a custom entity. The content-types allow to select one or multiple entities inside of a page template or a form.

Have a look at the [Extend Admin UI](https://docs.sulu.io/en/latest/book/extend-admin.html) documentation for more information about the changes in this PR.

![Screenshot 2020-10-30 at 16 42 00](https://user-images.githubusercontent.com/13310795/97725801-dbe90a00-1ace-11eb-81bc-7f542416eeef.png)

This PR builds upon #73. To use the content-types, you need to add a property with the respective type to a page template or a form:

```xml
<property name="single_event_selection" type="single_event_selection">
    <meta>
        <title lang="en">Single Event Selection</title>
    </meta>
</property>
``` 

```xml
<property name="event_selection" type="event_selection">
    <meta>
        <title lang="en">Event Selection</title>
    </meta>
</property>
``` 