### PR TITLE
[Example] Adjust ckeditor configuration

### DIFF
--- a/assets/admin/app.js
+++ b/assets/admin/app.js
@@ -1,1 +1,8 @@
 // Add project specific javascript code and import of additional bundles here:
+import {ckeditorPluginRegistry, ckeditorConfigRegistry} from 'sulu-admin-bundle/containers';
+import Font from '@ckeditor/ckeditor5-font/src/font';
+
+ckeditorPluginRegistry.add(Font);
+ckeditorConfigRegistry.add((config) => ({
+    toolbar: [...config.toolbar, 'fontSize', 'fontFamily', 'fontColor', 'fontBackgroundColor'],
+}));

--- a/assets/admin/package.json
+++ b/assets/admin/package.json
@@ -9,6 +9,7 @@
         "watch": "webpack --mode development --watch"
     },
     "dependencies": {
+        "@ckeditor/ckeditor5-font": "^27.1.0",
         "mobx": "^4.0.0",
         "mobx-react": "^5.0.0",
         "react": "^17.0.0",


### PR DESCRIPTION
#### What's in this PR?

This PR demonstrates how to configure the ckeditor instance which is used for `text_editor` properties. It utilizes the [`ckeditorPluginRegistry` and `ckeditorConfigRegistry`](https://jsdocs.sulu.io/latest/#ckeditor5) of Sulu to add and configure the [CKEditor 5 font feature](https://ckeditor.com/docs/ckeditor5/latest/api/font.html).

![Screenshot 2020-09-29 at 17 11 22](https://user-images.githubusercontent.com/13310795/94577398-d3ef3d80-0276-11eb-92cd-ea953aff17d9.png)

```js
// assets/admin/app.js
import {ckeditorPluginRegistry, ckeditorConfigRegistry} from 'sulu-admin-bundle/containers';
import Font from '@ckeditor/ckeditor5-font/src/font';

ckeditorPluginRegistry.add(Font);
ckeditorConfigRegistry.add((config) => ({
    toolbar: [...config.toolbar, 'fontSize', 'fontFamily', 'fontColor', 'fontBackgroundColor'],
}));
```

> [!WARNING]  
> Additional plugins need to be added to the `package.json` e.g.: `@ckeditor/ckeditor5-> font`, the CORRECT version is important for compatibility:

| Sulu Version | CKEditor Version |
|-------------|-------------------|
| 2.1              | [^18.0](https://github.com/sulu/sulu/blob/2.1.14/src/Sulu/Bundle/AdminBundle/Resources/js/package.json#L7) |
| 2.2               | [^23.0](https://github.com/sulu/sulu/blob/2.2.19/src/Sulu/Bundle/AdminBundle/Resources/js/package.json#L7) |
| 2.3               | [^27.1.0](https://github.com/sulu/sulu/blob/2.3.13/src/Sulu/Bundle/AdminBundle/Resources/js/package.json#L7) |
| 2.4               | [^31.0.0](https://github.com/sulu/sulu/blob/2.4.20/src/Sulu/Bundle/AdminBundle/Resources/js/package.json#L7) |
| 2.5               | [^34.2.0](https://github.com/sulu/sulu/blob/2.5.33/src/Sulu/Bundle/AdminBundle/Resources/js/package.json#L7) |
| 2.6 - 2.6.22  | [^41.2.1](https://github.com/sulu/sulu/blob/2.6.22/src/Sulu/Bundle/AdminBundle/Resources/js/package.json#L7) |
| 2.6.23               | [47.6.*](https://github.com/sulu/sulu/blob/2.6.22/src/Sulu/Bundle/AdminBundle/Resources/js/package.json#L7) |
| 2.6.24               | [^48.0](https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/AdminBundle/Resources/js/package.json#L6) |

A hint that you installed a wrong version of your plugin is the following error message:

> `Uncaught CKEditorError: ckeditor-duplicated-modules Read more: https://ckeditor.com/docs/ckeditor5/latest/support/error-codes.html#error-ckeditor-duplicated-modules`

To apply the changes, the administration frontend application needs to be rebuilt by executing `bin/console sulu:admin:update-build`.