### PR TITLE
[Example] Create, register and use custom field-type and content-type

### DIFF
--- a/assets/admin/app.js
+++ b/assets/admin/app.js
@@ -1,1 +1,5 @@
 // Add project specific javascript code and import of additional bundles here:
+import {fieldRegistry} from 'sulu-admin-bundle/containers';
+import Currency from "./fields/Currency";
+
+fieldRegistry.add('currency', Currency);

--- a/assets/admin/fields/Currency.js
+++ b/assets/admin/fields/Currency.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import {Number} from 'sulu-admin-bundle/components';
+
+class Currency extends React.Component{
+    handleInputChange = (floatAmount) => {
+        const centAmount = floatAmount !== undefined ?
+            Math.floor(floatAmount * 100)
+            : undefined;
+
+        const allowNegativeAmount = this.props.schemaOptions.allowNegativeAmount !== undefined
+            ? this.props.schemaOptions.allowNegativeAmount.value
+            : false;
+
+        const normalizedCentAmount = !allowNegativeAmount && centAmount !== undefined
+            ? Math.max(0, centAmount)
+            : centAmount;
+
+        this.props.onChange(normalizedCentAmount);
+        this.props.onFinish();
+    };
+
+    render() {
+        const {dataPath, disabled, error, value: centAmount} = this.props;
+
+        const floatAmount = centAmount !== undefined
+            ? centAmount / 100
+            : undefined;
+
+        return (
+            <Number
+                disabled={!!disabled}
+                icon="su-dollar"
+                id={dataPath}
+                onChange={this.handleInputChange}
+                step={0.01}
+                valid={!error}
+                value={floatAmount}
+            />
+        );
+    }
+}
+
+export default Currency;

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -44,3 +44,6 @@ services:
 
     App\Content\Type\AlbumSelection:
         tags: [{name: 'sulu.content.type', alias: 'album_selection'}]
+
+    App\Content\Type\Currency:
+        tags: [ { name: 'sulu.content.type', alias: 'currency' } ]

--- a/config/templates/pages/homepage.xml
+++ b/config/templates/pages/homepage.xml
@@ -69,6 +69,17 @@
             </properties>
         </section>
 
+        <property name="price" type="currency">
+            <meta>
+                <title lang="en">Price</title>
+                <title lang="de">Preis</title>
+            </meta>
+
+            <params>
+                <param name="allowNegativeAmount" value="true"/>
+            </params>
+        </property>
+
         <section name="content">
             <meta>
                 <title lang="en">Content</title>

--- a/src/Content/Type/Currency.php
+++ b/src/Content/Type/Currency.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Type;
+
+use Sulu\Component\Content\SimpleContentType;
+
+class Currency extends SimpleContentType
+{
+    public function __construct()
+    {
+        parent::__construct('currency');
+    }
+}

--- a/templates/pages/homepage.html.twig
+++ b/templates/pages/homepage.html.twig
@@ -5,5 +5,7 @@
 {% endblock %}
 
 {% block contentBody %}
+    Price Content Type Value: {{ content.price|default('not set') }}
+
     {% include 'includes/blocks.html.twig' %}
 {% endblock %}


### PR DESCRIPTION
#### What's in this PR?

This PR demonstrates how to implement a custom content type, which can be used inside of page templates and custom entity forms. The example registers a simple `currency` content type that displays an input with an icon in the administration interface and stores its amount in number of cents on the server. 

Have a look at the [Sulu Javascript Documentation](https://jsdocs.sulu.io/) for more information about the Javascript components and services included in Sulu. 

![Screenshot 2020-10-06 at 16 46 34](https://user-images.githubusercontent.com/13310795/95217494-85501f00-07f3-11eb-81a3-991256ecc991.png)

To apply the changes, the administration frontend application needs to be rebuilt by executing `bin/console sulu:admin:update-build`.