### PR TITLE
[Example] Implement custom field transformer to format data in list

### DIFF
--- a/assets/admin/fieldTransformers/ColoredTextFieldTransformer.js
+++ b/assets/admin/fieldTransformers/ColoredTextFieldTransformer.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const COLORS = ['gray', 'maroon', 'red', 'purple', 'green', 'blue', 'teal', 'orange', 'goldenrod', 'crimson']
+
+export default class ColoredTextFieldTransformer {
+    transform(value) {
+        const randomColor = COLORS[Math.floor(Math.random() * COLORS.length)];
+
+        return (
+            <div style={{color: randomColor}}>
+                {value}
+            </div>
+        );
+    }
+}

--- a/assets/admin/index.js
+++ b/assets/admin/index.js
@@ -18,6 +18,10 @@ import 'sulu-snippet-bundle';
 import 'sulu-website-bundle';
 
 // Implement custom extensions here
+import {listFieldTransformerRegistry} from 'sulu-admin-bundle/containers';
+import ColoredTextFieldTransformer from "./fieldTransformers/ColoredTextFieldTransformer";
+
+listFieldTransformerRegistry.add('colored_text', new ColoredTextFieldTransformer());
 
 // Start admin application
 startAdmin();

--- a/config/lists/albums.xml
+++ b/config/lists/albums.xml
@@ -30,7 +30,7 @@
             <entity-name>App\Entity\Album</entity-name>
         </property>
 
-        <property name="title" visibility="always" searchability="yes" translation="sulu_admin.title">
+        <property name="title" visibility="always" searchability="yes" translation="sulu_admin.title" type="colored_text">
             <field-name>title</field-name>
             <entity-name>App\Entity\Album</entity-name>
         </property>


### PR DESCRIPTION
#### What's in this PR?

This PR demonstrates how to implement a custom field transformer, which can be used to format data inside of lists. The example registers a simple `colored_text` field transformer that renders the data of the column with a random color. 

![Screenshot 2020-10-06 at 17 41 44](https://user-images.githubusercontent.com/13310795/95224668-3d34fa80-07fb-11eb-9d55-4ba9cd8744be.png)

To apply the changes, the administration frontend application needs to be rebuilt by executing `npm install` and `npm run build` in the `assets/admin` directory.