### PR TITLE
[Example] Add custom toolbar action to list view

### DIFF
--- a/assets/admin/index.js
+++ b/assets/admin/index.js
@@ -18,6 +18,10 @@ import 'sulu-snippet-bundle';
 import 'sulu-website-bundle';
 
 // Implement custom extensions here
+import {listToolbarActionRegistry} from 'sulu-admin-bundle/views';
+import AlertNamesToolbarAction from "./listToolbarActions/AlertNamesToolbarAction";
+
+listToolbarActionRegistry.add('app.alert_names', AlertNamesToolbarAction);
 
 // Start admin application
 startAdmin();

--- a/assets/admin/listToolbarActions/AlertNamesToolbarAction.js
+++ b/assets/admin/listToolbarActions/AlertNamesToolbarAction.js
@@ -1,0 +1,30 @@
+import {translate} from 'sulu-admin-bundle/utils';
+import {AbstractListToolbarAction} from 'sulu-admin-bundle/views';
+
+export default class AlertNamesToolbarAction extends AbstractListToolbarAction {
+    getToolbarItemConfig() {
+        const {disable_for_empty_selection: disableForEmptySelection = false} = this.options;
+
+        return {
+            type: 'button',
+            label: translate('app.alert_names'),
+            icon: 'su-bell',
+            disabled: disableForEmptySelection && this.listStore.selections.length === 0,
+            onClick: this.handleClick,
+        };
+    }
+
+    handleClick = () => {
+        if (this.listStore.selections.length === 0) {
+            alert(translate('app.no_contacts_selected'));
+
+            return;
+        }
+
+        const selectedNames = this.listStore.selections
+            .map((item) => item.firstName + ' ' + item.lastName)
+            .join('\n');
+
+        alert(translate('app.selected_contacts') + ':\n' + selectedNames);
+    };
+}

--- a/src/Admin/AppAdmin.php
+++ b/src/Admin/AppAdmin.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin;
+
+use Sulu\Bundle\AdminBundle\Admin\Admin;
+use Sulu\Bundle\AdminBundle\Admin\View\ListViewBuilderInterface;
+use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\ContactBundle\Admin\ContactAdmin;
+
+class AppAdmin extends Admin
+{
+    public function configureViews(ViewCollection $viewCollection): void
+    {
+        if ($viewCollection->has(ContactAdmin::CONTACT_LIST_VIEW)) {
+            /** @var ListViewBuilderInterface $contactListViewBuilder */
+            $contactListViewBuilder = $viewCollection->get(ContactAdmin::CONTACT_LIST_VIEW);
+            $contactListViewBuilder->addToolbarActions([
+                new ToolbarAction('app.alert_names', ['disable_for_empty_selection' => true]),
+            ]);
+        }
+    }
+
+    public static function getPriority(): int
+    {
+        return ContactAdmin::getPriority() - 1;
+    }
+}

--- a/translations/admin.de.json
+++ b/translations/admin.de.json
@@ -9,5 +9,8 @@
     "app.album_selection_label": "{count} {count, plural, =1 {Album} other {Alben}} ausgewählt",
     "app.select_albums": "Alben auswählen",
     "app.no_album_selected": "Kein Album ausgewählt",
-    "app.select_album": "Album auswählen"
+    "app.select_album": "Album auswählen",
+    "app.alert_names": "Namen ausgeben",
+    "app.no_contacts_selected": "Keine Kontakte ausgewählt",
+    "app.selected_contacts": "Ausgewählte Kontakte"
 }

--- a/translations/admin.en.json
+++ b/translations/admin.en.json
@@ -9,5 +9,8 @@
     "app.album_selection_label": "{count} {count, plural, =1 {album} other {albums}} selected",
     "app.select_albums": "Select albums",
     "app.no_album_selected": "No album selected",
-    "app.select_album": "Select album"
+    "app.select_album": "Select album",
+    "app.alert_names": "Alert Names",
+    "app.no_contacts_selected": "No contacts selected",
+    "app.selected_contacts": "Selected contacts"
 }


### PR DESCRIPTION
#### What's in this PR?

This PR demonstrates how to add a custom toolbar action to a list view of the administration interface of Sulu. The example adds a simple toolbar action that outputs the names of the selected contacts to the contact list view.

![Screenshot 2020-10-07 at 15 07 10](https://user-images.githubusercontent.com/13310795/95334759-ceb17480-08ae-11eb-8c3d-3f42de69b348.png)

To apply the changes, the administration frontend application needs to be rebuilt by executing `npm install` and `npm run build` in the `assets/admin` directory.