### PR TITLE
[Example] Add custom toolbar action to form view

### DIFF
--- a/assets/admin/formToolbarActions/GenerateNameToolbarAction.js
+++ b/assets/admin/formToolbarActions/GenerateNameToolbarAction.js
@@ -1,0 +1,29 @@
+import {translate} from 'sulu-admin-bundle/utils';
+import {AbstractFormToolbarAction} from 'sulu-admin-bundle/views';
+
+const FIRSTNAMES = ['James', 'Mary', 'John', 'Patricia', 'Robert', 'Jennifer', 'Michael', 'Linda']
+const LASTNAMES = ['Smith', 'Johnson', 'Williams', 'Brown', 'Jones', 'Miller', 'Davis', 'Garcia']
+
+export default class GenerateNameToolbarAction extends AbstractFormToolbarAction {
+    getToolbarItemConfig() {
+        const {allow_overwrite: allowOverwrite = false} = this.options;
+        const formData = this.resourceFormStore.data;
+        const nameAlreadySet = !!formData.firstName || !!formData.lastName;
+
+        return {
+            type: 'button',
+            label: translate('app.generate_name'),
+            icon: 'su-magic',
+            disabled: !allowOverwrite && nameAlreadySet,
+            onClick: this.handleClick,
+        };
+    }
+
+    handleClick = () => {
+        const randomFirstName = FIRSTNAMES[Math.floor(Math.random() * FIRSTNAMES.length)];
+        this.resourceFormStore.change('firstName', randomFirstName);
+
+        const randomLastName = LASTNAMES[Math.floor(Math.random() * LASTNAMES.length)];
+        this.resourceFormStore.change('lastName', randomLastName);
+    };
+}

--- a/assets/admin/index.js
+++ b/assets/admin/index.js
@@ -18,6 +18,10 @@ import 'sulu-snippet-bundle';
 import 'sulu-website-bundle';
 
 // Implement custom extensions here
+import {formToolbarActionRegistry} from 'sulu-admin-bundle/views';
+import GenerateNameToolbarAction from "./formToolbarActions/GenerateNameToolbarAction";
+
+formToolbarActionRegistry.add('app.generate_name', GenerateNameToolbarAction);
 
 // Start admin application
 startAdmin();

--- a/src/Admin/AppAdmin.php
+++ b/src/Admin/AppAdmin.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin;
+
+use Sulu\Bundle\AdminBundle\Admin\Admin;
+use Sulu\Bundle\AdminBundle\Admin\View\FormViewBuilderInterface;
+use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\ContactBundle\Admin\ContactAdmin;
+
+class AppAdmin extends Admin
+{
+    public function configureViews(ViewCollection $viewCollection): void
+    {
+        if ($viewCollection->has('sulu_contact.contact_add_form.details')) {
+            /** @var FormViewBuilderInterface $contactAddFormViewBuilder */
+            $contactAddFormViewBuilder = $viewCollection->get('sulu_contact.contact_add_form.details');
+            $contactAddFormViewBuilder->addToolbarActions([
+                new ToolbarAction('app.generate_name', ['allow_overwrite' => true]),
+            ]);
+        }
+    }
+
+    public static function getPriority(): int
+    {
+        return ContactAdmin::getPriority() - 1;
+    }
+}

--- a/translations/admin.de.json
+++ b/translations/admin.de.json
@@ -9,5 +9,6 @@
     "app.album_selection_label": "{count} {count, plural, =1 {Album} other {Alben}} ausgewählt",
     "app.select_albums": "Alben auswählen",
     "app.no_album_selected": "Kein Album ausgewählt",
-    "app.select_album": "Album auswählen"
+    "app.select_album": "Album auswählen",
+    "app.generate_name": "Namen ausgeben"
 }

--- a/translations/admin.en.json
+++ b/translations/admin.en.json
@@ -9,5 +9,6 @@
     "app.album_selection_label": "{count} {count, plural, =1 {album} other {albums}} selected",
     "app.select_albums": "Select albums",
     "app.no_album_selected": "No album selected",
-    "app.select_album": "Select album"
+    "app.select_album": "Select album",
+    "app.generate_name": "Generate name"
 }


### PR DESCRIPTION
#### What's in this PR?

This PR demonstrates how to add a custom toolbar action to a form view of the administration interface of Sulu. The example adds a simple toolbar action for inserting a random name to the add contact form view.

![Screenshot 2020-10-07 at 15 58 16](https://user-images.githubusercontent.com/13310795/95340853-f35d1a80-08b5-11eb-9314-70534e4d6ac5.png)

To apply the changes, the administration frontend application needs to be rebuilt by executing `npm install` and `npm run build` in the `assets/admin` directory.
