### PR TITLE
[Example] Integrate custom entity into the administration interface

### DIFF
--- a/config/forms/event_details.xml
+++ b/config/forms/event_details.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>event_details</key>
+
+    <properties>
+        <property name="name" type="text_line" mandatory="true" colspan="12">
+            <meta>
+                <title>sulu_admin.name</title>
+            </meta>
+            <params>
+                <param name="headline" value="true"/>
+            </params>
+        </property>
+
+        <property name="startDate" type="date" colspan="6">
+            <meta>
+                <title>app.start_date</title>
+            </meta>
+        </property>
+
+        <property name="endDate" type="date" colspan="6">
+            <meta>
+                <title>app.end_date</title>
+            </meta>
+        </property>
+    </properties>
+</form>

--- a/config/lists/events.xml
+++ b/config/lists/events.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<list xmlns="http://schemas.sulu.io/list-builder/list">
+    <key>events</key>
+
+    <properties>
+        <property name="id" visibility="no" translation="sulu_admin.id">
+            <field-name>id</field-name>
+            <entity-name>App\Entity\Event</entity-name>
+        </property>
+
+        <property name="name" visibility="always" searchability="yes" translation="sulu_admin.name">
+            <field-name>name</field-name>
+            <entity-name>App\Entity\Event</entity-name>
+        </property>
+
+        <property name="startDate" visibility="yes" translation="app.start_date" type="date">
+            <field-name>startDate</field-name>
+            <entity-name>App\Entity\Event</entity-name>
+        </property>
+
+        <property name="endDate" visibility="yes" translation="app.end_date" type="date">
+            <field-name>endDate</field-name>
+            <entity-name>App\Entity\Event</entity-name>
+        </property>
+    </properties>
+</list>

--- a/config/packages/sulu_admin.yaml
+++ b/config/packages/sulu_admin.yaml
@@ -11,6 +11,10 @@ sulu_admin:
             routes:
                 list: 'app.get_albums'
                 detail: 'app.get_album'
+        events:
+            routes:
+                list: 'app.get_events'
+                detail: 'app.get_event'
     field_type_options:
         selection:
             album_selection:

--- a/config/routes_admin.yaml
+++ b/config/routes_admin.yaml
@@ -4,3 +4,9 @@ app_albums_api:
     prefix: /admin/api
     resource: App\Controller\Admin\AlbumController
     name_prefix: app.
+
+app_events_api:
+    type: rest
+    prefix: /admin/api
+    resource: App\Controller\Admin\EventController
+    name_prefix: app.

--- a/src/Admin/EventAdmin.php
+++ b/src/Admin/EventAdmin.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin;
+
+use App\Entity\Event;
+use Sulu\Bundle\AdminBundle\Admin\Admin;
+use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
+use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
+use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
+
+class EventAdmin extends Admin
+{
+    const LIST_VIEW = 'app.event.list';
+    const ADD_FORM_VIEW = 'app.event.add_form';
+    const ADD_FORM_DETAILS_VIEW = 'app.event.add_form.details';
+    const EDIT_FORM_VIEW = 'app.event.edit_form';
+    const EDIT_FORM_DETAILS_VIEW = 'app.event.edit_form.details';
+
+    private ViewBuilderFactoryInterface $viewBuilderFactory;
+    private SecurityCheckerInterface $securityChecker;
+
+    public function __construct(
+        ViewBuilderFactoryInterface $viewBuilderFactory,
+        SecurityCheckerInterface $securityChecker
+    ) {
+        $this->viewBuilderFactory = $viewBuilderFactory;
+        $this->securityChecker = $securityChecker;
+    }
+
+    public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
+    {
+        if ($this->securityChecker->hasPermission(Event::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            $rootNavigationItem = new NavigationItem('app.events');
+            $rootNavigationItem->setIcon('su-calendar');
+            $rootNavigationItem->setPosition(30);
+            $rootNavigationItem->setView(static::LIST_VIEW);
+
+            $navigationItemCollection->add($rootNavigationItem);
+        }
+    }
+
+    public function configureViews(ViewCollection $viewCollection): void
+    {
+        $formToolbarActions = [];
+        $listToolbarActions = [];
+
+        if ($this->securityChecker->hasPermission(Event::SECURITY_CONTEXT, PermissionTypes::ADD)) {
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
+        }
+
+        if ($this->securityChecker->hasPermission(Event::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            $formToolbarActions[] = new ToolbarAction('sulu_admin.save');
+        }
+
+        if ($this->securityChecker->hasPermission(Event::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
+            $formToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+        }
+
+        if ($this->securityChecker->hasPermission(Event::SECURITY_CONTEXT, PermissionTypes::VIEW)) {
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
+        }
+
+        if ($this->securityChecker->hasPermission(Event::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            $viewCollection->add(
+                $this->viewBuilderFactory->createListViewBuilder(static::LIST_VIEW, '/events')
+                    ->setResourceKey(Event::RESOURCE_KEY)
+                    ->setListKey(Event::LIST_KEY)
+                    ->setTitle('app.events')
+                    ->addListAdapters(['table'])
+                    ->setAddView(static::ADD_FORM_VIEW)
+                    ->setEditView(static::EDIT_FORM_VIEW)
+                    ->addToolbarActions($listToolbarActions)
+            );
+
+            $viewCollection->add(
+                $this->viewBuilderFactory->createResourceTabViewBuilder(static::ADD_FORM_VIEW, '/events/add')
+                    ->setResourceKey(Event::RESOURCE_KEY)
+                    ->setBackView(static::LIST_VIEW)
+            );
+
+            $viewCollection->add(
+                $this->viewBuilderFactory->createFormViewBuilder(static::ADD_FORM_DETAILS_VIEW, '/details')
+                    ->setResourceKey(Event::RESOURCE_KEY)
+                    ->setFormKey(Event::FORM_KEY)
+                    ->setTabTitle('sulu_admin.details')
+                    ->setEditView(static::EDIT_FORM_VIEW)
+                    ->addToolbarActions($formToolbarActions)
+                    ->setParent(static::ADD_FORM_VIEW)
+            );
+
+            $viewCollection->add(
+                $this->viewBuilderFactory->createResourceTabViewBuilder(static::EDIT_FORM_VIEW, '/events/:id')
+                    ->setResourceKey(Event::RESOURCE_KEY)
+                    ->setBackView(static::LIST_VIEW)
+            );
+
+            $viewCollection->add(
+                $this->viewBuilderFactory->createFormViewBuilder(static::EDIT_FORM_DETAILS_VIEW, '/details')
+                    ->setResourceKey(Event::RESOURCE_KEY)
+                    ->setFormKey(Event::FORM_KEY)
+                    ->setTabTitle('sulu_admin.details')
+                    ->addToolbarActions($formToolbarActions)
+                    ->setParent(static::EDIT_FORM_VIEW)
+            );
+        }
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getSecurityContexts(): array
+    {
+        return [
+            self::SULU_ADMIN_SECURITY_SYSTEM => [
+                'Events' => [
+                    Event::SECURITY_CONTEXT => [
+                        PermissionTypes::VIEW,
+                        PermissionTypes::ADD,
+                        PermissionTypes::EDIT,
+                        PermissionTypes::DELETE,
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Controller/Admin/EventController.php
+++ b/src/Controller/Admin/EventController.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Common\DoctrineListRepresentationFactory;
+use App\Entity\Event;
+use Doctrine\ORM\EntityManagerInterface;
+use FOS\RestBundle\View\ViewHandlerInterface;
+use HandcraftedInTheAlps\RestRoutingBundle\Controller\Annotations\RouteResource;
+use HandcraftedInTheAlps\RestRoutingBundle\Routing\ClassResourceInterface;
+use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
+use Sulu\Component\Rest\AbstractRestController;
+use Sulu\Component\Security\SecuredControllerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * @RouteResource("event")
+ */
+class EventController extends AbstractRestController implements ClassResourceInterface, SecuredControllerInterface
+{
+    private DoctrineListRepresentationFactory $doctrineListRepresentationFactory;
+    private EntityManagerInterface $entityManager;
+    private MediaManagerInterface $mediaManager;
+
+    public function __construct(
+        DoctrineListRepresentationFactory $doctrineListRepresentationFactory,
+        EntityManagerInterface $entityManager,
+        MediaManagerInterface $mediaManager,
+        ViewHandlerInterface $viewHandler,
+        ?TokenStorageInterface $tokenStorage = null
+    ) {
+        $this->doctrineListRepresentationFactory = $doctrineListRepresentationFactory;
+        $this->entityManager = $entityManager;
+        $this->mediaManager = $mediaManager;
+
+        parent::__construct($viewHandler, $tokenStorage);
+    }
+
+    public function cgetAction(): Response
+    {
+        $listRepresentation = $this->doctrineListRepresentationFactory->createDoctrineListRepresentation(
+            Event::RESOURCE_KEY
+        );
+
+        return $this->handleView($this->view($listRepresentation));
+    }
+
+    public function getAction(int $id): Response
+    {
+        $event = $this->entityManager->getRepository(Event::class)->find($id);
+        if (!$event) {
+            throw new NotFoundHttpException();
+        }
+
+        return $this->handleView($this->view($event));
+    }
+
+    public function putAction(Request $request, int $id): Response
+    {
+        $event = $this->entityManager->getRepository(Event::class)->find($id);
+        if (!$event) {
+            throw new NotFoundHttpException();
+        }
+
+        $this->mapDataToEntity($request->request->all(), $event);
+        $this->entityManager->flush();
+
+        return $this->handleView($this->view($event));
+    }
+
+    public function postAction(Request $request): Response
+    {
+        $event = new Event();
+
+        $this->mapDataToEntity($request->request->all(), $event);
+        $this->entityManager->persist($event);
+        $this->entityManager->flush();
+
+        return $this->handleView($this->view($event, 201));
+    }
+
+    public function deleteAction(int $id): Response
+    {
+        /** @var Event $event */
+        $event = $this->entityManager->getReference(Event::class, $id);
+        $this->entityManager->remove($event);
+        $this->entityManager->flush();
+
+        return $this->handleView($this->view(null, 204));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    protected function mapDataToEntity(array $data, Event $entity): void
+    {
+        $entity->setName($data['name']);
+        $entity->setStartDate($data['startDate'] ? new \DateTimeImmutable($data['startDate']) : null);
+        $entity->setEndDate($data['endDate'] ? new \DateTimeImmutable($data['endDate']) : null);
+    }
+
+    public function getSecurityContext(): string
+    {
+        return Event::SECURITY_CONTEXT;
+    }
+}

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="app_event")
+ * @Serializer\ExclusionPolicy("all")
+ */
+class Event
+{
+    public const RESOURCE_KEY = 'events';
+    public const FORM_KEY = 'event_details';
+    public const LIST_KEY = 'events';
+    public const SECURITY_CONTEXT = 'sulu.events.events';
+
+    /**
+     * @ORM\Id()
+     * @ORM\GeneratedValue()
+     * @ORM\Column(type="integer")
+     *
+     * @Serializer\Expose()
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     *
+     * @Serializer\Expose()
+     */
+    private string $name;
+
+    /**
+     * @ORM\Column(type="datetime_immutable", nullable=true)
+     *
+     * @Serializer\Expose()
+     */
+    private ?\DateTimeImmutable $startDate;
+
+    /**
+     * @ORM\Column(type="datetime_immutable", nullable=true)
+     *
+     * @Serializer\Expose()
+     */
+    private ?\DateTimeImmutable $endDate;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name ?? '';
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getStartDate(): ?\DateTimeImmutable
+    {
+        return $this->startDate;
+    }
+
+    public function setStartDate(?\DateTimeImmutable $startDate): void
+    {
+        $this->startDate = $startDate;
+    }
+
+    public function getEndDate(): ?\DateTimeImmutable
+    {
+        return $this->endDate;
+    }
+
+    public function setEndDate(?\DateTimeImmutable $endDate): void
+    {
+        $this->endDate = $endDate;
+    }
+}

--- a/translations/admin.de.json
+++ b/translations/admin.de.json
@@ -9,5 +9,8 @@
     "app.album_selection_label": "{count} {count, plural, =1 {Album} other {Alben}} ausgewählt",
     "app.select_albums": "Alben auswählen",
     "app.no_album_selected": "Kein Album ausgewählt",
-    "app.select_album": "Album auswählen"
+    "app.select_album": "Album auswählen",
+    "app.events": "Events",
+    "app.start_date": "Startdatum",
+    "app.end_date": "Enddatum"
 }

--- a/translations/admin.en.json
+++ b/translations/admin.en.json
@@ -9,5 +9,8 @@
     "app.album_selection_label": "{count} {count, plural, =1 {album} other {albums}} selected",
     "app.select_albums": "Select albums",
     "app.no_album_selected": "No album selected",
-    "app.select_album": "Select album"
+    "app.select_album": "Select album",
+    "app.events": "Events",
+    "app.start_date": "Start Date",
+    "app.end_date": "End Date"
 }


### PR DESCRIPTION
#### What's in this PR?

This PR demonstrates how to integrate an entity into the administration interface of Sulu. The example implements a simple `Event` entity that consists of a name, a start-date and an end-date. The entity is persisted using [Doctrine](https://www.doctrine-project.org/) and the API for managing the entity is implemented using the [FOSRestBundle](https://symfony.com/doc/current/bundles/FOSRestBundle/).

Have a look at the [Extend Admin UI](https://docs.sulu.io/en/latest/book/extend-admin.html) documentation for more information about the changes in this PR.

![Screenshot 2020-10-27 at 16 37 37](https://user-images.githubusercontent.com/13310795/97324965-bfe92c80-1872-11eb-81a9-2580f0fea7a1.png)

To apply the changes, the schema of the database needs to be updated by executing `bin/console doctrine:schema:update --force`. Furthermore, the permissions for the Event entity need to be added to the `User` user role via the administration interface.