### PR TITLE
[Example] Add selection content-type for custom entity

### DIFF
--- a/config/forms/event_details.xml
+++ b/config/forms/event_details.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>event_details</key>
+
+    <properties>
+        <property name="name" type="text_line" mandatory="true" colspan="12">
+            <meta>
+                <title>sulu_admin.name</title>
+            </meta>
+            <params>
+                <param name="headline" value="true"/>
+            </params>
+        </property>
+
+        <property name="startDate" type="date" colspan="6">
+            <meta>
+                <title>app.start_date</title>
+            </meta>
+        </property>
+
+        <property name="endDate" type="date" colspan="6">
+            <meta>
+                <title>app.end_date</title>
+            </meta>
+        </property>
+    </properties>
+</form>

--- a/config/lists/events.xml
+++ b/config/lists/events.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<list xmlns="http://schemas.sulu.io/list-builder/list">
+    <key>events</key>
+
+    <properties>
+        <property name="id" visibility="no" translation="sulu_admin.id">
+            <field-name>id</field-name>
+            <entity-name>App\Entity\Event</entity-name>
+        </property>
+
+        <property name="name" visibility="always" searchability="yes" translation="sulu_admin.name">
+            <field-name>name</field-name>
+            <entity-name>App\Entity\Event</entity-name>
+        </property>
+
+        <property name="startDate" visibility="yes" translation="app.start_date" type="date">
+            <field-name>startDate</field-name>
+            <entity-name>App\Entity\Event</entity-name>
+        </property>
+
+        <property name="endDate" visibility="yes" translation="app.end_date" type="date">
+            <field-name>endDate</field-name>
+            <entity-name>App\Entity\Event</entity-name>
+        </property>
+    </properties>
+</list>

--- a/config/packages/sulu_admin.yaml
+++ b/config/packages/sulu_admin.yaml
@@ -29,6 +29,22 @@ sulu_admin:
                         icon: 'su-storage'
                         label: 'app.album_selection_label'
                         overlay_title: 'app.select_albums'
+            event_selection:
+                default_type: 'list_overlay'
+                resource_key: 'events'
+                view:
+                    name: 'app.event.add_form'
+                    result_to_view:
+                        id: 'id'
+                types:
+                    list_overlay:
+                        adapter: 'table'
+                        list_key: 'events'
+                        display_properties:
+                            - 'name'
+                        icon: 'su-calendar'
+                        label: 'app.event_selection_label'
+                        overlay_title: 'app.select_events'
         single_selection:
             single_album_selection:
                 default_type: 'list_overlay'
@@ -42,3 +58,19 @@ sulu_admin:
                         icon: 'su-storage'
                         empty_text: 'app.no_album_selected'
                         overlay_title: 'app.select_album'
+            single_event_selection:
+                default_type: 'list_overlay'
+                resource_key: 'events'
+                view:
+                    name: 'app.event.add_form'
+                    result_to_view:
+                        id: 'id'
+                types:
+                    list_overlay:
+                        adapter: 'table'
+                        list_key: 'events'
+                        display_properties:
+                            - 'name'
+                        icon: 'su-calendar'
+                        empty_text: 'app.no_event_selected'
+                        overlay_title: 'app.select_event'

--- a/config/packages/sulu_admin.yaml
+++ b/config/packages/sulu_admin.yaml
@@ -11,6 +11,10 @@ sulu_admin:
             routes:
                 list: 'app.get_albums'
                 detail: 'app.get_album'
+        events:
+            routes:
+                list: 'app.get_events'
+                detail: 'app.get_event'
     field_type_options:
         selection:
             album_selection:

--- a/config/routes_admin.yaml
+++ b/config/routes_admin.yaml
@@ -4,3 +4,9 @@ app_albums_api:
     prefix: /admin/api
     resource: App\Controller\Admin\AlbumController
     name_prefix: app.
+
+app_events_api:
+    type: rest
+    prefix: /admin/api
+    resource: App\Controller\Admin\EventController
+    name_prefix: app.

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -47,3 +47,9 @@ services:
 
     App\Content\Type\AlbumSelection:
         tags: [{name: 'sulu.content.type', alias: 'album_selection'}]
+
+    App\Content\Type\SingleEventSelection:
+        tags: [ { name: 'sulu.content.type', alias: 'single_event_selection' } ]
+
+    App\Content\Type\EventSelection:
+        tags: [ { name: 'sulu.content.type', alias: 'event_selection' } ]

--- a/src/Admin/EventAdmin.php
+++ b/src/Admin/EventAdmin.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin;
+
+use App\Entity\Event;
+use Sulu\Bundle\AdminBundle\Admin\Admin;
+use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
+use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
+use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
+
+class EventAdmin extends Admin
+{
+    const LIST_VIEW = 'app.event.list';
+    const ADD_FORM_VIEW = 'app.event.add_form';
+    const ADD_FORM_DETAILS_VIEW = 'app.event.add_form.details';
+    const EDIT_FORM_VIEW = 'app.event.edit_form';
+    const EDIT_FORM_DETAILS_VIEW = 'app.event.edit_form.details';
+
+    private ViewBuilderFactoryInterface $viewBuilderFactory;
+    private SecurityCheckerInterface $securityChecker;
+
+    public function __construct(
+        ViewBuilderFactoryInterface $viewBuilderFactory,
+        SecurityCheckerInterface $securityChecker
+    ) {
+        $this->viewBuilderFactory = $viewBuilderFactory;
+        $this->securityChecker = $securityChecker;
+    }
+
+    public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
+    {
+        if ($this->securityChecker->hasPermission(Event::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            $rootNavigationItem = new NavigationItem('app.events');
+            $rootNavigationItem->setIcon('su-calendar');
+            $rootNavigationItem->setPosition(30);
+            $rootNavigationItem->setView(static::LIST_VIEW);
+
+            $navigationItemCollection->add($rootNavigationItem);
+        }
+    }
+
+    public function configureViews(ViewCollection $viewCollection): void
+    {
+        $formToolbarActions = [];
+        $listToolbarActions = [];
+
+        if ($this->securityChecker->hasPermission(Event::SECURITY_CONTEXT, PermissionTypes::ADD)) {
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
+        }
+
+        if ($this->securityChecker->hasPermission(Event::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            $formToolbarActions[] = new ToolbarAction('sulu_admin.save');
+        }
+
+        if ($this->securityChecker->hasPermission(Event::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
+            $formToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+        }
+
+        if ($this->securityChecker->hasPermission(Event::SECURITY_CONTEXT, PermissionTypes::VIEW)) {
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
+        }
+
+        if ($this->securityChecker->hasPermission(Event::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            $viewCollection->add(
+                $this->viewBuilderFactory->createListViewBuilder(static::LIST_VIEW, '/events')
+                    ->setResourceKey(Event::RESOURCE_KEY)
+                    ->setListKey(Event::LIST_KEY)
+                    ->setTitle('app.events')
+                    ->addListAdapters(['table'])
+                    ->setAddView(static::ADD_FORM_VIEW)
+                    ->setEditView(static::EDIT_FORM_VIEW)
+                    ->addToolbarActions($listToolbarActions)
+            );
+
+            $viewCollection->add(
+                $this->viewBuilderFactory->createResourceTabViewBuilder(static::ADD_FORM_VIEW, '/events/add')
+                    ->setResourceKey(Event::RESOURCE_KEY)
+                    ->setBackView(static::LIST_VIEW)
+            );
+
+            $viewCollection->add(
+                $this->viewBuilderFactory->createFormViewBuilder(static::ADD_FORM_DETAILS_VIEW, '/details')
+                    ->setResourceKey(Event::RESOURCE_KEY)
+                    ->setFormKey(Event::FORM_KEY)
+                    ->setTabTitle('sulu_admin.details')
+                    ->setEditView(static::EDIT_FORM_VIEW)
+                    ->addToolbarActions($formToolbarActions)
+                    ->setParent(static::ADD_FORM_VIEW)
+            );
+
+            $viewCollection->add(
+                $this->viewBuilderFactory->createResourceTabViewBuilder(static::EDIT_FORM_VIEW, '/events/:id')
+                    ->setResourceKey(Event::RESOURCE_KEY)
+                    ->setBackView(static::LIST_VIEW)
+            );
+
+            $viewCollection->add(
+                $this->viewBuilderFactory->createFormViewBuilder(static::EDIT_FORM_DETAILS_VIEW, '/details')
+                    ->setResourceKey(Event::RESOURCE_KEY)
+                    ->setFormKey(Event::FORM_KEY)
+                    ->setTabTitle('sulu_admin.details')
+                    ->addToolbarActions($formToolbarActions)
+                    ->setParent(static::EDIT_FORM_VIEW)
+            );
+        }
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getSecurityContexts(): array
+    {
+        return [
+            self::SULU_ADMIN_SECURITY_SYSTEM => [
+                'Events' => [
+                    Event::SECURITY_CONTEXT => [
+                        PermissionTypes::VIEW,
+                        PermissionTypes::ADD,
+                        PermissionTypes::EDIT,
+                        PermissionTypes::DELETE,
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Content/Type/EventSelection.php
+++ b/src/Content/Type/EventSelection.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Type;
+
+use App\Entity\Event;
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\SimpleContentType;
+
+class EventSelection extends SimpleContentType
+{
+    protected EntityManagerInterface $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+
+        parent::__construct('event_selection', []);
+    }
+
+    /**
+     * @return Event[]
+     */
+    public function getContentData(PropertyInterface $property): array
+    {
+        $ids = $property->getValue();
+
+        if (empty($ids)) {
+            return [];
+        }
+
+        $events = $this->entityManager->getRepository(Event::class)->findBy(['id' => $ids]);
+
+        $idPositions = array_flip($ids);
+        usort($events, function (Event $a, Event $b) use ($idPositions) {
+            return $idPositions[$a->getId()] - $idPositions[$b->getId()];
+        });
+
+        return $events;
+    }
+
+    /**
+     * @return array<string, array<int>|null>
+     */
+    public function getViewData(PropertyInterface $property): array
+    {
+        return [
+            'ids' => $property->getValue(),
+        ];
+    }
+}

--- a/src/Content/Type/SingleEventSelection.php
+++ b/src/Content/Type/SingleEventSelection.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Type;
+
+use App\Entity\Event;
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\SimpleContentType;
+
+class SingleEventSelection extends SimpleContentType
+{
+    protected EntityManagerInterface $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+
+        parent::__construct('single_event_selection', null);
+    }
+
+    public function getContentData(PropertyInterface $property): ?Event
+    {
+        $id = $property->getValue();
+
+        if (empty($id)) {
+            return null;
+        }
+
+        return $this->entityManager->getRepository(Event::class)->find($id);
+    }
+
+    /**
+     * @return array<string, int|null>
+     */
+    public function getViewData(PropertyInterface $property): array
+    {
+        return [
+            'id' => $property->getValue(),
+        ];
+    }
+}

--- a/src/Controller/Admin/EventController.php
+++ b/src/Controller/Admin/EventController.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Common\DoctrineListRepresentationFactory;
+use App\Entity\Event;
+use Doctrine\ORM\EntityManagerInterface;
+use FOS\RestBundle\View\ViewHandlerInterface;
+use HandcraftedInTheAlps\RestRoutingBundle\Controller\Annotations\RouteResource;
+use HandcraftedInTheAlps\RestRoutingBundle\Routing\ClassResourceInterface;
+use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
+use Sulu\Component\Rest\AbstractRestController;
+use Sulu\Component\Security\SecuredControllerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * @RouteResource("event")
+ */
+class EventController extends AbstractRestController implements ClassResourceInterface, SecuredControllerInterface
+{
+    private DoctrineListRepresentationFactory $doctrineListRepresentationFactory;
+    private EntityManagerInterface $entityManager;
+    private MediaManagerInterface $mediaManager;
+
+    public function __construct(
+        DoctrineListRepresentationFactory $doctrineListRepresentationFactory,
+        EntityManagerInterface $entityManager,
+        MediaManagerInterface $mediaManager,
+        ViewHandlerInterface $viewHandler,
+        ?TokenStorageInterface $tokenStorage = null
+    ) {
+        $this->doctrineListRepresentationFactory = $doctrineListRepresentationFactory;
+        $this->entityManager = $entityManager;
+        $this->mediaManager = $mediaManager;
+
+        parent::__construct($viewHandler, $tokenStorage);
+    }
+
+    public function cgetAction(): Response
+    {
+        $listRepresentation = $this->doctrineListRepresentationFactory->createDoctrineListRepresentation(
+            Event::RESOURCE_KEY
+        );
+
+        return $this->handleView($this->view($listRepresentation));
+    }
+
+    public function getAction(int $id): Response
+    {
+        $event = $this->entityManager->getRepository(Event::class)->find($id);
+        if (!$event) {
+            throw new NotFoundHttpException();
+        }
+
+        return $this->handleView($this->view($event));
+    }
+
+    public function putAction(Request $request, int $id): Response
+    {
+        $event = $this->entityManager->getRepository(Event::class)->find($id);
+        if (!$event) {
+            throw new NotFoundHttpException();
+        }
+
+        $this->mapDataToEntity($request->request->all(), $event);
+        $this->entityManager->flush();
+
+        return $this->handleView($this->view($event));
+    }
+
+    public function postAction(Request $request): Response
+    {
+        $event = new Event();
+
+        $this->mapDataToEntity($request->request->all(), $event);
+        $this->entityManager->persist($event);
+        $this->entityManager->flush();
+
+        return $this->handleView($this->view($event, 201));
+    }
+
+    public function deleteAction(int $id): Response
+    {
+        /** @var Event $event */
+        $event = $this->entityManager->getReference(Event::class, $id);
+        $this->entityManager->remove($event);
+        $this->entityManager->flush();
+
+        return $this->handleView($this->view(null, 204));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    protected function mapDataToEntity(array $data, Event $entity): void
+    {
+        $entity->setName($data['name']);
+        $entity->setStartDate($data['startDate'] ? new \DateTimeImmutable($data['startDate']) : null);
+        $entity->setEndDate($data['endDate'] ? new \DateTimeImmutable($data['endDate']) : null);
+    }
+
+    public function getSecurityContext(): string
+    {
+        return Event::SECURITY_CONTEXT;
+    }
+}

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="app_event")
+ * @Serializer\ExclusionPolicy("all")
+ */
+class Event
+{
+    public const RESOURCE_KEY = 'events';
+    public const FORM_KEY = 'event_details';
+    public const LIST_KEY = 'events';
+    public const SECURITY_CONTEXT = 'sulu.events.events';
+
+    /**
+     * @ORM\Id()
+     * @ORM\GeneratedValue()
+     * @ORM\Column(type="integer")
+     *
+     * @Serializer\Expose()
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     *
+     * @Serializer\Expose()
+     */
+    private string $name;
+
+    /**
+     * @ORM\Column(type="datetime_immutable", nullable=true)
+     *
+     * @Serializer\Expose()
+     */
+    private ?\DateTimeImmutable $startDate;
+
+    /**
+     * @ORM\Column(type="datetime_immutable", nullable=true)
+     *
+     * @Serializer\Expose()
+     */
+    private ?\DateTimeImmutable $endDate;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name ?? '';
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getStartDate(): ?\DateTimeImmutable
+    {
+        return $this->startDate;
+    }
+
+    public function setStartDate(?\DateTimeImmutable $startDate): void
+    {
+        $this->startDate = $startDate;
+    }
+
+    public function getEndDate(): ?\DateTimeImmutable
+    {
+        return $this->endDate;
+    }
+
+    public function setEndDate(?\DateTimeImmutable $endDate): void
+    {
+        $this->endDate = $endDate;
+    }
+}

--- a/translations/admin.de.json
+++ b/translations/admin.de.json
@@ -12,5 +12,9 @@
     "app.select_album": "Album auswählen",
     "app.events": "Events",
     "app.start_date": "Startdatum",
-    "app.end_date": "Enddatum"
+    "app.end_date": "Enddatum",
+    "app.event_selection_label": "{count} {count, plural, =1 {Event} other {Events}} ausgewählt",
+    "app.select_events": "Events auswählen",
+    "app.no_event_selected": "Kein Event ausgewählt",
+    "app.select_event": "Event auswählen"
 }

--- a/translations/admin.de.json
+++ b/translations/admin.de.json
@@ -9,5 +9,8 @@
     "app.album_selection_label": "{count} {count, plural, =1 {Album} other {Alben}} ausgewählt",
     "app.select_albums": "Alben auswählen",
     "app.no_album_selected": "Kein Album ausgewählt",
-    "app.select_album": "Album auswählen"
+    "app.select_album": "Album auswählen",
+    "app.events": "Events",
+    "app.start_date": "Startdatum",
+    "app.end_date": "Enddatum"
 }

--- a/translations/admin.en.json
+++ b/translations/admin.en.json
@@ -12,5 +12,9 @@
     "app.select_album": "Select album",
     "app.events": "Events",
     "app.start_date": "Start Date",
-    "app.end_date": "End Date"
+    "app.end_date": "End Date",
+    "app.event_selection_label": "{count} {count, plural, =1 {event} other {events}} selected",
+    "app.select_events": "Select events",
+    "app.no_event_selected": "No event selected",
+    "app.select_event": "Select event"
 }

--- a/translations/admin.en.json
+++ b/translations/admin.en.json
@@ -9,5 +9,8 @@
     "app.album_selection_label": "{count} {count, plural, =1 {album} other {albums}} selected",
     "app.select_albums": "Select albums",
     "app.no_album_selected": "No album selected",
-    "app.select_album": "Select album"
+    "app.select_album": "Select album",
+    "app.events": "Events",
+    "app.start_date": "Start Date",
+    "app.end_date": "End Date"
 }


### PR DESCRIPTION
#### What's in this PR?

This PR demonstrates how to add a `selection` and `single_selection` content-type for a custom entity. The content-types allow to select one or multiple entities inside of a page template or a form.

Have a look at the [Extend Admin UI](https://docs.sulu.io/en/latest/book/extend-admin.html) documentation for more information about the changes in this PR.

![Screenshot 2020-10-30 at 16 42 00](https://user-images.githubusercontent.com/13310795/97725801-dbe90a00-1ace-11eb-81bc-7f542416eeef.png)

This PR builds upon #73. To use the content-types, you need to add a property with the respective type to a page template or a form:

```xml
<property name="single_event_selection" type="single_event_selection">
    <meta>
        <title lang="en">Single Event Selection</title>
    </meta>
</property>
``` 

```xml
<property name="event_selection" type="event_selection">
    <meta>
        <title lang="en">Event Selection</title>
    </meta>
</property>
``` 