### PR TITLE
[Example] Add additional tab to built-in contact entity

### DIFF
--- a/config/forms/additional_contact_data.xml
+++ b/config/forms/additional_contact_data.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>additional_contact_data</key>
+
+    <properties>
+        <property name="socialSecurityNumber" type="text_line" colspan="6">
+            <meta>
+                <title>app.social_security_number</title>
+            </meta>
+        </property>
+
+        <property name="externalCrmId" type="text_line" colspan="6">
+            <meta>
+                <title>app.external_crm_id</title>
+            </meta>
+        </property>
+    </properties>
+</form>

--- a/config/packages/app_additional_contact_data_admin.yaml
+++ b/config/packages/app_additional_contact_data_admin.yaml
@@ -1,0 +1,5 @@
+sulu_admin:
+    resources:
+        additional_contact_data:
+            routes:
+                detail: 'app.get_additional-contact-data'

--- a/config/packages/sulu_contact.yaml
+++ b/config/packages/sulu_contact.yaml
@@ -1,0 +1,4 @@
+sulu_contact:
+    objects:
+        contact:
+            model: 'App\Entity\Contact'

--- a/config/routes_admin.yaml
+++ b/config/routes_admin.yaml
@@ -4,3 +4,9 @@ app_albums_api:
     prefix: /admin/api
     resource: App\Controller\Admin\AlbumController
     name_prefix: app.
+
+app_additional_contact_data_api:
+    type: rest
+    prefix: /admin/api
+    resource: App\Controller\Admin\AdditionalContactDataController
+    name_prefix: app.

--- a/src/Admin/AdditionalContactDataAdmin.php
+++ b/src/Admin/AdditionalContactDataAdmin.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin;
+
+use Sulu\Bundle\AdminBundle\Admin\Admin;
+use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\ContactBundle\Admin\ContactAdmin;
+
+class AdditionalContactDataAdmin extends Admin
+{
+    /**
+     * @var ViewBuilderFactoryInterface
+     */
+    private $viewBuilderFactory;
+
+    public function __construct(
+        ViewBuilderFactoryInterface $viewBuilderFactory
+    ) {
+        $this->viewBuilderFactory = $viewBuilderFactory;
+    }
+
+    public function configureViews(ViewCollection $viewCollection): void
+    {
+        if ($viewCollection->has('sulu_contact.contact_edit_form.details')) {
+            $contactDetailsFormView = $viewCollection->get('sulu_contact.contact_edit_form.details')->getView();
+
+            $viewCollection->add(
+                $this->viewBuilderFactory
+                    ->createFormViewBuilder('app.additional_contact_data_form', '/additional-data')
+                    ->setResourceKey('additional_contact_data')
+                    ->setFormKey('additional_contact_data')
+                    ->setTabTitle('app.additional_data')
+                    ->addToolbarActions([new ToolbarAction('sulu_admin.save')])
+                    ->setTabOrder($contactDetailsFormView->getOption('tabOrder') + 1)
+                    ->setParent(ContactAdmin::CONTACT_EDIT_FORM_VIEW)
+            );
+        }
+    }
+
+    public static function getPriority(): int
+    {
+        return ContactAdmin::getPriority() - 1;
+    }
+}

--- a/src/Controller/Admin/AdditionalContactDataController.php
+++ b/src/Controller/Admin/AdditionalContactDataController.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Entity\Contact;
+use Doctrine\ORM\EntityManagerInterface;
+use FOS\RestBundle\View\ViewHandlerInterface;
+use HandcraftedInTheAlps\RestRoutingBundle\Controller\Annotations\RouteResource;
+use HandcraftedInTheAlps\RestRoutingBundle\Routing\ClassResourceInterface;
+use Sulu\Bundle\ContactBundle\Admin\ContactAdmin;
+use Sulu\Component\Rest\AbstractRestController;
+use Sulu\Component\Security\SecuredControllerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * @RouteResource("additional-contact-data")
+ */
+class AdditionalContactDataController extends AbstractRestController implements ClassResourceInterface, SecuredControllerInterface
+{
+    private EntityManagerInterface $entityManager;
+
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        ViewHandlerInterface $viewHandler,
+        ?TokenStorageInterface $tokenStorage = null
+    ) {
+        $this->entityManager = $entityManager;
+
+        parent::__construct($viewHandler, $tokenStorage);
+    }
+
+    public function getAction(int $id): Response
+    {
+        $contact = $this->entityManager->getRepository(Contact::class)->find($id);
+        if (!$contact) {
+            throw new NotFoundHttpException();
+        }
+
+        return $this->handleView($this->view($this->getDataForEntity($contact)));
+    }
+
+    public function putAction(Request $request, int $id): Response
+    {
+        $contact = $this->entityManager->getRepository(Contact::class)->find($id);
+        if (!$contact) {
+            throw new NotFoundHttpException();
+        }
+
+        $this->mapDataToEntity($request->request->all(), $contact);
+        $this->entityManager->flush();
+
+        return $this->handleView($this->view($this->getDataForEntity($contact)));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getDataForEntity(Contact $entity): array
+    {
+        return [
+            'id' => $entity->getId(),
+            'socialSecurityNumber' => $entity->getSocialSecurityNumber(),
+            'externalCrmId' => $entity->getExternalCrmId(),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    protected function mapDataToEntity(array $data, Contact $entity): void
+    {
+        $entity->setSocialSecurityNumber($data['socialSecurityNumber']);
+        $entity->setExternalCrmId($data['externalCrmId']);
+    }
+
+    public function getSecurityContext(): string
+    {
+        return ContactAdmin::CONTACT_SECURITY_CONTEXT;
+    }
+}

--- a/src/Entity/Contact.php
+++ b/src/Entity/Contact.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Sulu\Bundle\ContactBundle\Entity\Contact as SuluContact;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="co_contacts")
+ */
+class Contact extends SuluContact
+{
+    /**
+     * @ORM\Column(type="string", length=63, nullable=true)
+     */
+    private ?string $socialSecurityNumber;
+
+    /**
+     * @ORM\Column(type="string", length=63, nullable=true)
+     */
+    private ?string $externalCrmId;
+
+    public function getSocialSecurityNumber(): ?string
+    {
+        return $this->socialSecurityNumber;
+    }
+
+    public function setSocialSecurityNumber(?string $socialSecurityNumber): void
+    {
+        $this->socialSecurityNumber = $socialSecurityNumber;
+    }
+
+    public function getExternalCrmId(): ?string
+    {
+        return $this->externalCrmId;
+    }
+
+    public function setExternalCrmId(?string $externalCrmId): void
+    {
+        $this->externalCrmId = $externalCrmId;
+    }
+}

--- a/translations/admin.de.json
+++ b/translations/admin.de.json
@@ -10,5 +10,8 @@
     "app.album_selection_label": "{count} {count, plural, =1 {Album} other {Alben}} ausgewählt",
     "app.select_albums": "Alben auswählen",
     "app.no_album_selected": "Kein Album ausgewählt",
-    "app.select_album": "Album auswählen"
+    "app.select_album": "Album auswählen",
+    "app.additional_data": "Zusätzliche Daten",
+    "app.social_security_number": "Sozialversicherungsnummer",
+    "app.external_crm_id": "Externe CRM ID"
 }

--- a/translations/admin.en.json
+++ b/translations/admin.en.json
@@ -10,5 +10,8 @@
     "app.album_selection_label": "{count} {count, plural, =1 {album} other {albums}} selected",
     "app.select_albums": "Select albums",
     "app.no_album_selected": "No album selected",
-    "app.select_album": "Select album"
+    "app.select_album": "Select album",
+    "app.additional_data": "Additional Data",
+    "app.social_security_number": "Social Security number",
+    "app.external_crm_id": "External CRM ID"
 }


### PR DESCRIPTION
#### What's in this PR?

This PR demonstrates how to add an additional tab to the the built-in contact entity. The example [extends the contact entity](https://docs.sulu.io/en/latest/cookbook/extend-entities.html) to include two project-specific properties and [adds an additional tab to the contact form view](https://docs.sulu.io/en/latest/cookbook/add-admin-tabs.html) to manage the data.

![Screenshot 2021-02-12 at 16 39 23](https://user-images.githubusercontent.com/13310795/107788605-e1522380-6d50-11eb-884d-e437c8bc990c.png)

To apply the changes, the schema of the database needs to be updated by executing `bin/console doctrine:schema:update --force`.