### PR TITLE
[Example] Dispatch domain events for albums

### DIFF
--- a/src/Admin/AlbumAdmin.php
+++ b/src/Admin/AlbumAdmin.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Admin;
 
 use App\Entity\Album;
+use Sulu\Bundle\ActivityBundle\Infrastructure\Sulu\Admin\View\ActivityViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
@@ -23,13 +24,16 @@ class AlbumAdmin extends Admin
     const EDIT_FORM_DETAILS_VIEW = 'app.album.edit_form.details';
 
     private ViewBuilderFactoryInterface $viewBuilderFactory;
+    private ActivityViewBuilderFactoryInterface $activityViewBuilderFactory;
     private SecurityCheckerInterface $securityChecker;
 
     public function __construct(
         ViewBuilderFactoryInterface $viewBuilderFactory,
+        ActivityViewBuilderFactoryInterface $activityViewBuilderFactory,
         SecurityCheckerInterface $securityChecker
     ) {
         $this->viewBuilderFactory = $viewBuilderFactory;
+        $this->activityViewBuilderFactory = $activityViewBuilderFactory;
         $this->securityChecker = $securityChecker;
     }
 
@@ -102,6 +106,7 @@ class AlbumAdmin extends Admin
                 $this->viewBuilderFactory->createResourceTabViewBuilder(static::EDIT_FORM_VIEW, '/albums/:id')
                     ->setResourceKey(Album::RESOURCE_KEY)
                     ->setBackView(static::LIST_VIEW)
+                    ->setTitleProperty('title')
             );
 
             $viewCollection->add(
@@ -112,6 +117,18 @@ class AlbumAdmin extends Admin
                     ->addToolbarActions($formToolbarActions)
                     ->setParent(static::EDIT_FORM_VIEW)
             );
+
+            if ($this->activityViewBuilderFactory->hasActivityListPermission()) {
+                $viewCollection->add(
+                    $this->activityViewBuilderFactory
+                        ->createActivityListViewBuilder(
+                            static::EDIT_FORM_VIEW . '.activity',
+                            '/activity',
+                            Album::RESOURCE_KEY
+                        )
+                        ->setParent(static::EDIT_FORM_VIEW)
+                );
+            }
         }
     }
 

--- a/src/Domain/Event/AlbumCreatedEvent.php
+++ b/src/Domain/Event/AlbumCreatedEvent.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Event;
+
+use App\Entity\Album;
+use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+
+class AlbumCreatedEvent extends DomainEvent
+{
+    private Album $album;
+
+    /**
+     * @var mixed[]
+     */
+    private array $payload;
+
+    /**
+     * @param mixed[] $payload
+     */
+    public function __construct(Album $album, array $payload)
+    {
+        parent::__construct();
+
+        $this->album = $album;
+        $this->payload = $payload;
+    }
+
+    public function getAlbum(): Album
+    {
+        return $this->album;
+    }
+
+    public function getEventPayload(): ?array
+    {
+        return $this->payload;
+    }
+
+    public function getEventType(): string
+    {
+        return 'created';
+    }
+
+    public function getResourceKey(): string
+    {
+        return Album::RESOURCE_KEY;
+    }
+
+    public function getResourceId(): string
+    {
+        return (string) $this->album->getId();
+    }
+
+    public function getResourceTitle(): ?string
+    {
+        return $this->album->getTitle();
+    }
+
+    public function getResourceSecurityContext(): ?string
+    {
+        return Album::SECURITY_CONTEXT;
+    }
+}

--- a/src/Domain/Event/AlbumModifiedEvent.php
+++ b/src/Domain/Event/AlbumModifiedEvent.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Event;
+
+use App\Entity\Album;
+use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+
+class AlbumModifiedEvent extends DomainEvent
+{
+    private Album $album;
+
+    /**
+     * @var mixed[]
+     */
+    private array $payload;
+
+    /**
+     * @param mixed[] $payload
+     */
+    public function __construct(Album $album, array $payload)
+    {
+        parent::__construct();
+
+        $this->album = $album;
+        $this->payload = $payload;
+    }
+
+    public function getAlbum(): Album
+    {
+        return $this->album;
+    }
+
+    public function getEventPayload(): ?array
+    {
+        return $this->payload;
+    }
+
+    public function getEventType(): string
+    {
+        return 'modified';
+    }
+
+    public function getResourceKey(): string
+    {
+        return Album::RESOURCE_KEY;
+    }
+
+    public function getResourceId(): string
+    {
+        return (string) $this->album->getId();
+    }
+
+    public function getResourceTitle(): ?string
+    {
+        return $this->album->getTitle();
+    }
+
+    public function getResourceSecurityContext(): ?string
+    {
+        return Album::SECURITY_CONTEXT;
+    }
+}

--- a/src/Domain/Event/AlbumRemovedEvent.php
+++ b/src/Domain/Event/AlbumRemovedEvent.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Event;
+
+use App\Entity\Album;
+use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+
+class AlbumRemovedEvent extends DomainEvent
+{
+    private int $id;
+    private string $title;
+
+    public function __construct(int $id, string $title)
+    {
+        parent::__construct();
+
+        $this->id = $id;
+        $this->title = $title;
+    }
+
+    public function getEventType(): string
+    {
+        return 'removed';
+    }
+
+    public function getResourceKey(): string
+    {
+        return Album::RESOURCE_KEY;
+    }
+
+    public function getResourceId(): string
+    {
+        return (string) $this->id;
+    }
+
+    public function getResourceTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function getResourceSecurityContext(): ?string
+    {
+        return Album::SECURITY_CONTEXT;
+    }
+}

--- a/translations/admin.de.json
+++ b/translations/admin.de.json
@@ -10,5 +10,8 @@
     "app.album_selection_label": "{count} {count, plural, =1 {Album} other {Alben}} ausgewählt",
     "app.select_albums": "Alben auswählen",
     "app.no_album_selected": "Kein Album ausgewählt",
-    "app.select_album": "Album auswählen"
+    "app.select_album": "Album auswählen",
+    "sulu_activity.description.albums.created": "{userFullName} hat das Album \"{resourceTitle}\" erstellt",
+    "sulu_activity.description.albums.modified": "{userFullName} hat das Album \"{resourceTitle}\" geändert",
+    "sulu_activity.description.albums.removed": "{userFullName} hat das Album \"{resourceTitle}\" gelöscht"
 }

--- a/translations/admin.en.json
+++ b/translations/admin.en.json
@@ -10,5 +10,8 @@
     "app.album_selection_label": "{count} {count, plural, =1 {album} other {albums}} selected",
     "app.select_albums": "Select albums",
     "app.no_album_selected": "No album selected",
-    "app.select_album": "Select album"
+    "app.select_album": "Select album",
+    "sulu_activity.description.albums.created": "{userFullName} has created the album \"{resourceTitle}\"",
+    "sulu_activity.description.albums.modified": "{userFullName} has changed the album \"{resourceTitle}\"",
+    "sulu_activity.description.albums.removed": "{userFullName} has removed the album \"{resourceTitle}\""
 }


### PR DESCRIPTION
#### What's in this PR?

This pull request shows, how to dispatch domain events for custom entities and show them in the administration interface in a separate tab on the edit view of your custom entity.

![image](https://user-images.githubusercontent.com/5758674/119958424-5285b180-bfa3-11eb-9918-e2c643364f21.png)

#### Requirements

| Sulu | >= 2.3.1 |
| --- | --- |