### PR TITLE
Remove trailing slash on meta.html.twig

### DIFF
--- a/templates/includes/meta.html.twig
+++ b/templates/includes/meta.html.twig
@@ -78,27 +78,27 @@
 {# Meta Default Tags #}
 {% block metaDefaultTags %}
     {% for property, value in metaDefaultTags|filter((value) => value) %}
-    <meta name="{{ property }}" content="{{ value }}"/>
+    <meta name="{{ property }}" content="{{ value }}">
     {% endfor %}
 {% endblock %}
 
 {# Meta DC Tags #}
 {% block metaDCTags %}
     {% for property, value in metaDCTags|filter((value) => value) %}
-    <meta name="{{ property }}" content="{{ value }}"/>
+    <meta name="{{ property }}" content="{{ value }}">
     {% endfor %}
 {% endblock %}
 
 {# Meta Twitter Tags #}
 {% block metaTwitterTags %}
     {% for property, value in metaTwitterTags|filter((value) => value) %}
-    <meta name="{{ property }}" content="{{ value }}"/>
+    <meta name="{{ property }}" content="{{ value }}">
     {% endfor %}
 {% endblock %}
 
 {# Meta OG Tags #}
 {% block ogMetaTags %}
     {% for property, value in ogMetaTags|filter((value) => value) %}
-    <meta property="{{ property }}" content="{{ value }}"/>
+    <meta property="{{ property }}" content="{{ value }}">
     {% endfor %}
 {% endblock %}


### PR DESCRIPTION
From w3c validator

Info: Trailing slash on void elements [has no effect](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-in-void-element-start-tags-do-not-mark-the-start-tags-as-self-closing) and [interacts badly with unquoted attribute values](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-directly-preceded-by-unquoted-attribute-values).

[From line 12, column 9; to line 12, column 44](https://validator.w3.org/nu/#l12c44)

<meta name="language" content="en"/>

and so on

