### PR TITLE
Change Github CI to PHP 8.1

### DIFF
--- a/.github/workflows/test-application.yml
+++ b/.github/workflows/test-application.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     php:
-        name: PHP 8.0
+        name: PHP 8.1
         runs-on: ubuntu-latest
 
         services:
@@ -36,7 +36,7 @@ jobs:
             - name: Install and configure PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.0'
+                  php-version: '8.1'
                   extensions: ctype, iconv, mysql
                   coverage: none
                   tools: composer


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Change Github CI to PHP 8.1.

#### Why?

Github CI still runs on 8.0
