### PR TITLE
[Example] Extend User entity with attributes and lifecycle events

### DIFF
--- a/config/packages/sulu_security.yaml
+++ b/config/packages/sulu_security.yaml
@@ -1,4 +1,7 @@
 sulu_security:
+    objects:
+        user:
+            model: App\Entity\User
     checker:
         enabled: true
     password_policy:

--- a/src/Build/UserBuilder.php
+++ b/src/Build/UserBuilder.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Build;
 
+use App\Entity\User;
 use Doctrine\Persistence\ObjectManager;
 use Massive\Bundle\BuildBundle\Build\BuilderContext;
 use Massive\Bundle\BuildBundle\Build\BuilderInterface;
 use Sulu\Bundle\SecurityBundle\Build\UserBuilder as SuluUserBuilder;
-use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserSetting;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Sulu\Bundle\SecurityBundle\Entity\User as SuluUser;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'se_users')]
+#[ORM\HasLifecycleCallbacks]
+class User extends SuluUser
+{
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true, unique: true)]
+    private ?string $externalId = null;
+
+    public function getExternalId(): ?string
+    {
+        return $this->externalId;
+    }
+
+    public function setExternalId(?string $externalId): void
+    {
+        $this->externalId = $externalId;
+    }
+
+    #[ORM\PrePersist]
+    #[ORM\PreUpdate]
+    public function generateExternalIdIfEmpty(): void
+    {
+        if (null === $this->externalId || '' === $this->externalId) {
+            $this->externalId = Uuid::uuid7()->toString();
+        }
+    }
+}

--- a/tests/Functional/Entity/UserTest.php
+++ b/tests/Functional/Entity/UserTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Entity;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\ContactBundle\Entity\Contact;
+use Sulu\Bundle\SecurityBundle\Entity\Role;
+use Sulu\Bundle\SecurityBundle\Entity\UserRole;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+class UserTest extends SuluTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $this->purgeDatabase();
+        $this->entityManager = $this->getEntityManager();
+    }
+
+    public function testLifecycleCallbackGeneratesExternalIdOnPersist(): void
+    {
+        $user = $this->createUser('testuser');
+
+        // External ID should be null before persistence
+        $this->assertNull($user->getExternalId());
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        // External ID should be generated after persistence
+        $externalId = $user->getExternalId();
+        $this->assertNotNull($externalId);
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i',
+            $externalId,
+            'Generated external ID should be a valid UUID v7',
+        );
+    }
+
+    public function testLifecycleCallbackGeneratesExternalIdOnUpdate(): void
+    {
+        $user = $this->createUser('testuser');
+        $user->setExternalId('manually-set-id');
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        $this->assertSame('manually-set-id', $user->getExternalId());
+
+        // Clear the external ID and update
+        $user->setExternalId(null);
+        $user->setEmail('updated@example.com');
+
+        $this->entityManager->flush();
+
+        // External ID should be regenerated on update
+        $externalId = $user->getExternalId();
+        $this->assertNotNull($externalId);
+        $this->assertNotSame('manually-set-id', $externalId);
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i',
+            $externalId,
+        );
+    }
+
+    public function testExternalIdIsUniqueAcrossUsers(): void
+    {
+        $user1 = $this->createUser('user1');
+        $user2 = $this->createUser('user2');
+
+        $this->entityManager->persist($user1);
+        $this->entityManager->persist($user2);
+        $this->entityManager->flush();
+
+        $this->assertNotNull($user1->getExternalId());
+        $this->assertNotNull($user2->getExternalId());
+        $this->assertNotSame(
+            $user1->getExternalId(),
+            $user2->getExternalId(),
+            'Each user should have a unique external ID',
+        );
+    }
+
+    public function testExternalIdIsPersistedToDatabase(): void
+    {
+        $user = $this->createUser('testuser');
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        $externalId = $user->getExternalId();
+        $userId = $user->getId();
+
+        // Clear entity manager to force database reload
+        $this->entityManager->clear();
+
+        /** @var User|null $reloadedUser */
+        $reloadedUser = $this->entityManager->getRepository(User::class)->find($userId);
+
+        $this->assertNotNull($reloadedUser);
+        $this->assertSame($externalId, $reloadedUser->getExternalId());
+    }
+
+    public function testManuallySetExternalIdIsNotOverwritten(): void
+    {
+        $manualId = '01933e3f-8d6e-7a3e-a9e4-1234567890ab';
+        $user = $this->createUser('testuser');
+        $user->setExternalId($manualId);
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        $this->assertSame($manualId, $user->getExternalId());
+
+        // Update the user
+        $user->setEmail('updated@example.com');
+        $this->entityManager->flush();
+
+        // Manual ID should still be preserved
+        $this->assertSame($manualId, $user->getExternalId());
+    }
+
+    private function createUser(string $username): User
+    {
+        $user = new User();
+        $user->setUsername($username);
+        $user->setEmail($username . '@example.com');
+        $user->setPassword('password');
+        $user->setLocale('en');
+        $user->setSalt('salt');
+
+        // Create required contact
+        $contact = new Contact();
+        $contact->setFirstName('Test');
+        $contact->setLastName('User');
+        $this->entityManager->persist($contact);
+
+        $user->setContact($contact);
+
+        // Find or create required role
+        $role = $this->entityManager->getRepository(Role::class)->findOneBy([]);
+        if (!$role instanceof Role) {
+            $role = new Role();
+            $role->setName('TestRole');
+            $role->setSystem('Sulu');
+            $this->entityManager->persist($role);
+            $this->entityManager->flush();
+        }
+
+        $userRole = new UserRole();
+        $userRole->setRole($role);
+        $userRole->setUser($user);
+        $userRole->setLocale('["en"]');
+        $this->entityManager->persist($userRole);
+
+        $user->addUserRole($userRole);
+
+        return $user;
+    }
+}

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+class UserTest extends TestCase
+{
+    private User $user;
+
+    protected function setUp(): void
+    {
+        $this->user = new User();
+    }
+
+    public function testExternalIdGetterAndSetter(): void
+    {
+        $this->assertNull($this->user->getExternalId());
+
+        $externalId = '01933e3f-8d6e-7a3e-a9e4-1234567890ab';
+        $this->user->setExternalId($externalId);
+
+        $this->assertSame($externalId, $this->user->getExternalId());
+    }
+
+    public function testExternalIdCanBeSetToNull(): void
+    {
+        $this->user->setExternalId('01933e3f-8d6e-7a3e-a9e4-1234567890ab');
+        $this->assertNotNull($this->user->getExternalId());
+
+        $this->user->setExternalId(null);
+        $this->assertNull($this->user->getExternalId());
+    }
+
+    public function testGenerateExternalIdIfEmptyCreatesUuid(): void
+    {
+        $this->assertNull($this->user->getExternalId());
+
+        $this->user->generateExternalIdIfEmpty();
+
+        $externalId = $this->user->getExternalId();
+        $this->assertNotNull($externalId);
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i',
+            $externalId,
+            'Generated external ID should be a valid UUID v7',
+        );
+    }
+
+    public function testGenerateExternalIdIfEmptyDoesNotOverwriteExistingId(): void
+    {
+        $originalId = '01933e3f-8d6e-7a3e-a9e4-1234567890ab';
+        $this->user->setExternalId($originalId);
+
+        $this->user->generateExternalIdIfEmpty();
+
+        $this->assertSame($originalId, $this->user->getExternalId());
+    }
+
+    public function testGenerateExternalIdIfEmptyReplacesEmptyString(): void
+    {
+        $this->user->setExternalId('');
+
+        $this->user->generateExternalIdIfEmpty();
+
+        $externalId = $this->user->getExternalId();
+        $this->assertNotNull($externalId);
+        $this->assertNotSame('', $externalId);
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i',
+            $externalId,
+        );
+    }
+
+    public function testUserExtendsFromSuluUser(): void
+    {
+        $this->assertInstanceOf(\Sulu\Bundle\SecurityBundle\Entity\User::class, $this->user);
+    }
+
+    public function testMultipleCallsGenerateDifferentUuids(): void
+    {
+        $user1 = new User();
+        $user1->generateExternalIdIfEmpty();
+
+        $user2 = new User();
+        $user2->generateExternalIdIfEmpty();
+
+        $this->assertNotSame(
+            $user1->getExternalId(),
+            $user2->getExternalId(),
+            'Each user should get a unique external ID',
+        );
+    }
+}


### PR DESCRIPTION
This PR demonstrates how to extend Sulu's built-in User entity by:
- Adding a custom externalId property using PHP 8 attributes
- Implementing lifecycle callbacks for automatic UUID generation
- Configuring Sulu to use the custom entity class

Implementation:
- Created App\Entity\User extending Sulu\Bundle\SecurityBundle\Entity\User
- Added externalId field with unique constraint (nullable for backward compatibility)
- Used #[ORM\PrePersist] and #[ORM\PreUpdate] lifecycle callbacks
- Configured sulu_security.objects.user.model to use custom class
- Generated UUID v7 using ramsey/uuid library

This example shows the recommended pattern for extending any Sulu built-in entity while maintaining compatibility with the core system.