### PR TITLE
Use list overlay adapter for category to have search possibility

### DIFF
--- a/config/packages/sulu_admin.yaml
+++ b/config/packages/sulu_admin.yaml
@@ -29,6 +29,19 @@ sulu_admin:
                         icon: 'su-storage'
                         label: 'app.album_selection_label'
                         overlay_title: 'app.select_albums'
+
+            category_selection:
+                default_type: 'list_overlay' # change type to list_overlay by default
+                types:
+                    # adds new list overlay config
+                    list_overlay:
+                        adapter: 'tree_table_slim'
+                        list_key: 'categories'
+                        display_properties:
+                            - 'name'
+                        icon: 'su-tag'
+                        label: 'sulu_category.category_selection_label'
+                        overlay_title: 'sulu_category.category_selection_overlay_title'
         single_selection:
             single_album_selection:
                 default_type: 'list_overlay'

--- a/translations/admin.de.json
+++ b/translations/admin.de.json
@@ -1,4 +1,6 @@
 {
+    "sulu_category.category_selection_label": "{count} {count, plural, =1 {Kategorie} other {Kategorien}} ausgewählt",
+    "sulu_category.category_selection_overlay_title": "Kategorien auswählen",
     "app.music": "Musik",
     "app.album": "Album",
     "app.albums": "Alben",

--- a/translations/admin.en.json
+++ b/translations/admin.en.json
@@ -1,4 +1,6 @@
 {
+    "sulu_category.category_selection_label": "{count} {count, plural, =1 {Category} other {Categories}} selected",
+    "sulu_category.category_selection_overlay_title": "Select categories",
     "app.music": "Music",
     "app.album": "Album",
     "app.albums": "Albums",


### PR DESCRIPTION
Changing the adapter of categories allows to search inside the overlay:

![category_list_adapter](https://github.com/user-attachments/assets/657d629b-bc14-401d-8dc8-c9473f5d7551)
